### PR TITLE
[WebProfilerBundle] normalizer and encoder can be undefined in template

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -188,7 +188,9 @@
 {% macro render_normalizer_cell(item, index, method) %}
     {% set nested_normalizers_id = 'nested-normalizers-' ~ method ~ '-' ~ index %}
 
+    {% if item.normalizer is defined %}
     <span class="nowrap"><a href="{{ item.normalizer.file|file_link(item.normalizer.line) }}" title="{{ item.normalizer.file }}">{{ item.normalizer.class }}</a> ({{ '%.2f'|format(item.normalizer.time * 1000) }} ms)</span>
+    {% endif %}
 
     {% if item.normalization|length > 1 %}
         <div>
@@ -207,7 +209,9 @@
 {% macro render_encoder_cell(item, index, method) %}
     {% set nested_encoders_id = 'nested-encoders-' ~ method ~ '-' ~ index %}
 
+    {% if item.encoder is defined %}
     <span class="nowrap"><a href="{{ item.encoder.file|file_link(item.encoder.line) }}" title="{{ item.encoder.file }}">{{ item.encoder.class }}</a> ({{ '%.2f'|format(item.encoder.time * 1000) }} ms)</span>
+    {% endif %}
 
     {% if item.encoding|length > 1 %}
         <div>


### PR DESCRIPTION
fixes #46537

| Q             | A
| ------------- | ---
| Branch?       | 6.2 for features / 4.4, 5.4, 6.0 or 6.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #46537 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the latest branch.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
